### PR TITLE
log: Correct column titles

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -273,7 +273,7 @@ int main(int argc, const char** argv) {
 
   menu_files = Renderer(menu_files, [menu_files] {
     return vbox({
-        text("Commit"),
+        text("Files"),
         separator(),
         menu_files->Render() | vscroll_indicator | yframe | yflex,
     });
@@ -281,7 +281,7 @@ int main(int argc, const char** argv) {
 
   menu_commit = Renderer(menu_commit, [menu_commit] {
     return vbox({
-        text("Files"),
+        text("Commit"),
         separator(),
         menu_commit->Render() | vscroll_indicator | yframe | yflex,
     });


### PR DESCRIPTION
**[why]**
The column headers for 'files' and 'commits' are swapped.

This has been introduced with commit
  2c8d56e Use resizable split

**[how]**
Just change the string literals.

Fixes: #7
