### PR TITLE
diff: Keep user's background color

### DIFF
--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -304,7 +304,7 @@ int main(int argc, const char** argv) {
       ResizableSplitLeft(file_menu_renderer, file_renderer, &file_menu_width);
 
   auto layout_renderer = Renderer(layout, [&] {
-    return layout->Render() | bgcolor(Color::RGB(30, 30, 30)) | yflex;
+    return layout->Render() | yflex;
   });
 
   auto options = Container::Horizontal({


### PR DESCRIPTION
**[why]**
The background in the main area is hardcoded to dark grey (30,30,30).
This breaks the usability for people who have a light theme (i.e. black
or dark text on light background).

**[how]**
One solution would be to also change the foreground color, but that will
for sure irritate people who use 'solarized' or other themes.

Imho it would be best not to tinker with the background colors unless at
least light and dark is selectable as option (and ideally autoselect
depending on the used terminal's current background (vim for example
does that, adapt the color scheme to the current user selected
background in the terminal).

So the solution implemented here is to completely drop the change in
background color.

### Screenshots

Here two sets of screenshots. `tilix` is used in a `light` theme, while `terminal` is set up for a `dark` theme.

#### Before PR
![1](https://user-images.githubusercontent.com/16012374/154303368-e37ff839-35ac-4aa6-a238-c2fbfcaeb87f.png)

Background color in both terminals is the same, albeit `tilix` uses normally white and has black text while `terminal` uses black background and white text.

#### After PR
![2](https://user-images.githubusercontent.com/16012374/154303602-111efedb-30be-4425-ad8a-41b7136f5b4f.png)

Background color not touched anymore. This means it's not dark-gray anymore but the default background color, that matches the used default foreground color.